### PR TITLE
Install Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Inspired by [this](https://www.reddit.com/r/linuxmasterrace/comments/6glb85/sorr
 * `dpkg`
 * `pacman`
 * `pkginfo`
+* `portage`
 * `rpm`
 * `xpkg`
 

--- a/interjection.sh
+++ b/interjection.sh
@@ -13,6 +13,8 @@ elif which xpkg > /dev/null 2>&1; then
 elif which xbps-install > /dev/null 2>&1; then
     echo "Package 'xtools' is not installed. You can install it with 'xbps-install xtools'"
     exit 1
+elif which equery > /dev/null 2>&1; then
+	PACKAGES="$(equery list -F '$name' '*')"
 else
     # TODO portage and other package backends
     echo 'Your package manager is not supported.'

--- a/interjection.sh
+++ b/interjection.sh
@@ -14,9 +14,11 @@ elif which xbps-install > /dev/null 2>&1; then
     echo "Package 'xtools' is not installed. You can install it with 'xbps-install xtools'"
     exit 1
 elif which equery > /dev/null 2>&1; then
-	PACKAGES="$(equery list -F '$name' '*')"
+    PACKAGES="$(equery list -F '$name' '*')"
+elif which emerge > /dev/null 2>&1; then
+    PACKAGES="$(ls -d -1 /var/db/pkg/*/* | cut -c 13- | cut -d/ -f1 --complement | sed 's/-[0-9].*//')"
 else
-    # TODO portage and other package backends
+    # TODO other package backends
     echo 'Your package manager is not supported.'
     exit 1
 fi


### PR DESCRIPTION
Added support for the Portage package manager (using two methods actually). First using `equery`, which is really easy to use, but not installed by default. Second with a more complicated (yet for some reason faster) `ls` of /var/db/pkg.

Also updated list of supported package managers.

Output is as expected:

![Output Image](https://neat.fuerbringer.info/f353c2183b3cffb8f969b413944d0cce1a0c9195699273defa08fc70806abf0b.png)