### PR TITLE
Add nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Inspired by [this](https://www.reddit.com/r/linuxmasterrace/comments/6glb85/sorr
 
 ### Supported Package Management Systems
 
+* `brew`
 * `dpkg`
+* `nix`
 * `pacman`
 * `pkginfo`
 * `portage`
 * `rpm`
 * `xpkg`
-* `brew`
 
 Pull requests are more than welcome for those that are not currently supported! See [`CONTRIBUTING.md`](https://github.com/JoshuaRLi/interjection.sh/blob/master/CONTRIBUTING.md) for more information.
 

--- a/interjection.sh
+++ b/interjection.sh
@@ -19,6 +19,8 @@ elif command -v emerge > /dev/null 2>&1; then
     PACKAGES="$(ls -d -1 /var/db/pkg/*/* | cut -c 13- | cut -d/ -f1 --complement | sed 's/-[0-9].*//')"
 elif command -v brew > /dev/null 2>&1; then
     PACKAGES="$(brew list)"
+elif command -v nixos-version > /dev/null 2>&1; then
+    PACKAGES="$(ls -d -1 /nix/store/*/ | cut -c 45- | sed 's/-[0-9].*//' | sort | uniq)"
 else
     # TODO other package backends
     echo 'Your package manager is not supported.'

--- a/interjection.sh
+++ b/interjection.sh
@@ -20,7 +20,7 @@ elif command -v emerge > /dev/null 2>&1; then
 elif command -v brew > /dev/null 2>&1; then
     PACKAGES="$(brew list)"
 elif command -v nixos-version > /dev/null 2>&1; then
-    PACKAGES="$(ls -d -1 /nix/store/*/ | cut -c 45- | sed 's/-[0-9].*//' | sort | uniq)"
+    PACKAGES="$(ls -d -1 /nix/store/*/ | cut -c 45- | sed 's/.$//' | sed 's/-[0-9].*//' | sort | uniq)"
 else
     # TODO other package backends
     echo 'Your package manager is not supported.'


### PR DESCRIPTION
Former Gentoo guy here. Now that I changed to NixOS I thought I might aswell add nix support here and learn something about how nix works.

### Explanation

#### 1. `ls -d -1 /nix/store/*/`
List the *globally* installed packages. Output: `/nix/store/5973lr6ss1v91cbz5jr4yh494yp3h0j6-vim-8.0.0329/`

#### 2. `cut -c 45-`
Cut off the first 45 characters. Output: `vim-8.0.0329/`

#### 3. `sed 's/.$//'`
Remove trailing `/` if present. Output: `vim-8.0.0329`

#### 4. `sed 's/-[0-9].*//'`
Filter out the package name: Output: `vim`

#### 5. and 6.
Sort and remove duplicates (of which there are potentially lots on NixOS).

### Result
![Preview](https://0x0.st/sNjC.png)

----

Note: I took the liberty of `:sort`ing the `Supported Package Management Systems` because why not.
Another note: This will not work with nix installed on anything other than NixOS. But this is expected since other distros have their own dedicated package managers.